### PR TITLE
Adapt for implementation of RFC-65.

### DIFF
--- a/examples/simple-example/simple-example.pony
+++ b/examples/simple-example/simple-example.pony
@@ -8,14 +8,7 @@ actor Main
   new create(env: Env) =>
     let limit = try env.args(1)?.usize()? else 1 end
 
-    let auth =
-      try
-        env.root as AmbientAuth
-      else
-        env.out.print("unable to use the network")
-        return
-      end
-
+    let auth = env.root
     let sslctx =
       try
         // paths need to be adjusted to a absolute location or you need to run

--- a/net_ssl/_test.pony
+++ b/net_ssl/_test.pony
@@ -555,13 +555,9 @@ class _TestTCP is TCPListenNotify
     h.expect_action("client create")
     h.expect_action("server accept")
 
-    try
-      let auth = h.env.root as AmbientAuth
-      h.dispose_when_done(TCPListener(auth, consume this))
-      h.complete_action("server create")
-    else
-      h.fail_action("server create")
-    end
+    let auth = h.env.root
+    h.dispose_when_done(TCPListener(auth, consume this))
+    h.complete_action("server create")
 
     h.long_test(2_000_000_000)
 
@@ -572,7 +568,7 @@ class _TestTCP is TCPListenNotify
     _h.complete_action("server listen")
 
     try
-      let auth = _h.env.root as AmbientAuth
+      let auth = _h.env.root
       let notify = (_client_conn_notify = None) as TCPConnectionNotify iso^
       (let host, let port) = listen.local_address().name()?
       _h.dispose_when_done(TCPConnection(auth, consume notify, host, port))
@@ -625,7 +621,7 @@ primitive _TestSSLContext
   fun val apply(h: TestHelper): (SSL iso^, SSL iso^) ? =>
     let sslctx =
       try
-        let auth = h.env.root as AmbientAuth
+        let auth = h.env.root
         recover
           SSLContext
             .> set_authority(FilePath(auth, "assets/cert.pem")?)?


### PR DESCRIPTION
changing Env.root from (AmbientAuth | None) to AmbientAuth.

This needs to wait until https://github.com/ponylang/ponyc/pull/3558 is merged/released.