### PR TITLE
Add the ability to load Windows root certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ TAGS
 tags
 .deps/*
 /*.lib
+.vscode

--- a/.release-notes/38.md
+++ b/.release-notes/38.md
@@ -1,0 +1,3 @@
+# Add the ability to load Windows root certificates
+
+Adds a change to `SSLContext` so that if `set_authority(None, None)` is called on Windows, it will load the root certificates from the Windows certificate store. On Posix the call will raise an error as before.


### PR DESCRIPTION
This PR changes `SSLContext` so that if `set_authority(None, None)` is called on Windows, it will load the root certificates from the Windows certificate store. On Posix the call will raise an error as before.

The reason for this change is that the `http` package has a test that loads certs from `/usr/share/ca-certificates/mozilla`. There is no equivalent directory on Windows, the root certs can only be retrieved programmatically.