### PR TITLE
Remove explicit return type from FFI calls

### DIFF
--- a/.release-notes/48.md
+++ b/.release-notes/48.md
@@ -1,0 +1,4 @@
+## Forward prepare for coming breaking FFI change in ponyc
+
+Added FFI declarations to all FFI calls in the library. The change has no impact on end users, but will future proof against a coming breaking change in FFI in the ponyc compiler. Users of this version of the library won't be impacted by the coming change.
+

--- a/net_ssl/ssl.pony
+++ b/net_ssl/ssl.pony
@@ -73,7 +73,7 @@ class SSL
     _output = @BIO_new(@BIO_s_mem())
     if _output.is_null() then error end
 
-    @SSL_set_bio[None](_ssl, _input, _output)
+    @SSL_set_bio(_ssl, _input, _output)
 
     if
       (_hostname.size() > 0)

--- a/net_ssl/x509.pony
+++ b/net_ssl/x509.pony
@@ -129,7 +129,7 @@ primitive X509
           end)
       end
 
-      @GENERAL_NAME_free[None](name)
+      @GENERAL_NAME_free(name)
       ifdef "openssl_1.1.x" then
         name = @OPENSSL_sk_pop(stack)
       elseif "openssl_0.9.0" then


### PR DESCRIPTION
Seems like I forgot to remove this during the last PR, sorry!