### PR TITLE
Add path to Homebrew's LibreSSL on ARM macOS

### DIFF
--- a/.release-notes/54.md
+++ b/.release-notes/54.md
@@ -1,0 +1,3 @@
+## Add path to Homebrew's LibreSSL on ARM macOS
+
+With the release of ponyc 0.45.0, Apple Silicon is now a supported platform, which means that the default install location of Homebrew formulas has changed. This release of net_ssl allows to build the library without using the ponyc `--path` option to include LibreSSL.

--- a/net_ssl/_ssl_init.pony
+++ b/net_ssl/_ssl_init.pony
@@ -1,4 +1,5 @@
-use "path:/usr/local/opt/libressl/lib" if osx
+use "path:/usr/local/opt/libressl/lib" if osx and x86
+use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:ssl"
 use "lib:crypto"
 


### PR DESCRIPTION
As discussed on #51, Homebrew moved from installing packages under `/usr/local` to
`/opt/homebrew` for Apple Silicon processors.

Another popular alternative to Homebrew, MacPorts, is already covered by
including `/opt/local/lib`.

Fixes #51 