### PR TITLE
Update to reflect change in type of Env.root

### DIFF
--- a/.release-notes/env-root.md
+++ b/.release-notes/env-root.md
@@ -1,0 +1,5 @@
+## Update to work with latest ponyc
+
+The most recent ponyc implements [RFC #65](https://github.com/ponylang/rfcs/blob/main/text/0065-env-root-not-optional.md) which changes the type of `Env.root`.
+
+We've updated accordingly. You won't be able to use this and future versions of the library without a corresponding update to your ponyc version.

--- a/examples/simple-example/simple-example.pony
+++ b/examples/simple-example/simple-example.pony
@@ -8,13 +8,7 @@ actor Main
   new create(env: Env) =>
     let limit = try env.args(1)?.usize()? else 1 end
 
-    let auth =
-      try
-        env.root as AmbientAuth
-      else
-        env.out.print("unable to use the network")
-        return
-      end
+    let auth = env.root
 
     let sslctx =
       try

--- a/net_ssl/_test.pony
+++ b/net_ssl/_test.pony
@@ -291,7 +291,7 @@ class iso _TestWindowsLoadRootCertificates is UnitTest
 
   fun ref apply(h: TestHelper) =>
     try
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       let ssl_ctx =
         recover
           SSLContext
@@ -587,13 +587,9 @@ class _TestTCP is TCPListenNotify
     h.expect_action("client create")
     h.expect_action("server accept")
 
-    try
-      let auth = h.env.root as AmbientAuth
-      h.dispose_when_done(TCPListener(auth, consume this))
-      h.complete_action("server create")
-    else
-      h.fail_action("server create")
-    end
+    let auth = h.env.root
+    h.dispose_when_done(TCPListener(auth, consume this))
+    h.complete_action("server create")
 
     h.long_test(2_000_000_000)
 
@@ -604,7 +600,7 @@ class _TestTCP is TCPListenNotify
     _h.complete_action("server listen")
 
     try
-      let auth = _h.env.root as AmbientAuth
+      let auth = _h.env.root
       let notify = (_client_conn_notify = None) as TCPConnectionNotify iso^
       (let host, let port) = listen.local_address().name()?
       _h.dispose_when_done(TCPConnection(auth, consume notify, host, port))
@@ -657,7 +653,7 @@ primitive _TestSSLContext
   fun val apply(h: TestHelper): (SSL iso^, SSL iso^) ? =>
     let sslctx =
       try
-        let auth = h.env.root as AmbientAuth
+        let auth = h.env.root
         recover
           SSLContext
             .> set_authority(FilePath(auth, "assets/cert.pem"))?


### PR DESCRIPTION
The type of Env.root was changed as part of RFC #65:

https://github.com/ponylang/rfcs/blob/main/text/0065-env-root-not-optional.md

Shouldn't be merged until https://github.com/ponylang/ponyc/pull/3962 is merged.