### PR TITLE
Change location we download LibreSSL from for Windows users

### DIFF
--- a/.release-notes/openbsd.md
+++ b/.release-notes/openbsd.md
@@ -1,0 +1,7 @@
+## Update the URL for Windows LibreSSL downloads
+
+Previously, as part of the Windows install process of `net_ssl`, we would download a copy of LibreSSL from ftp.openbsd.org, build and install it.
+
+We've found that ftp.openbsd.org has become flakey but cdn.openbsd.org has been stable.
+
+There's no change that you need to do as a user for this update, however, if you are having trouble with this library on Windows due to it being unable to successfully download LibreSSL, this update is for you.

--- a/make.ps1
+++ b/make.ps1
@@ -156,7 +156,7 @@ function BuildLibs
     {
       $libreSslTgz = "$libreSsl.tar.gz"
       $libreSslTgzTgt = Join-Path -Path $libsDir -ChildPath $libreSslTgz
-      if (-not (Test-Path $libreSslTgzTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/$libreSslTgz" -OutFile $libreSslTgzTgt }
+      if (-not (Test-Path $libreSslTgzTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "http://cdn.openbsd.org/pub/OpenBSD/LibreSSL/$libreSslTgz" -OutFile $libreSslTgzTgt }
       7z.exe x -y $libreSslTgzTgt "-o$libsDir"
       if ($LastExitCode -ne 0) { throw "Error downloading and unzipping $libreSslTgz" }
       7z.exe x -y "$libsDir/$libreSsl.tar" "-o$libsDir"


### PR DESCRIPTION
ftp.openbsd.org appears to be flakey. cdn.freebsd.org appears to be a lot more stable.