### PR TITLE
Update OpenSSL 3 testing to 3.2.0

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -51,7 +51,7 @@ jobs:
     name: OpenSSL 3.x with ponyc main
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.3:latest
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.2.0:latest
     steps:
       - uses: actions/checkout@v3
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
     name: OpenSSL 3.x with most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.3:release
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.2.0:release
     steps:
       - uses: actions/checkout@v3
       - name: Test


### PR DESCRIPTION
A bug that impacts on net_ssl was identified by a user. That bug isn't present in 3.1.x but is in 3.2.0.

This commit updates us to use 3.2.0 so we can:

- Find a test to do that triggers the bug
- Verify a fix by seeing the bug go away