### PR TITLE
[RFC] Add support for static linking of libressl

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
         run: make test config=debug ssl=0.9.0
 
   test-static-libressl-3-vs-ponyc-release:
-    name: LibreSSL 3.x with most recent ponyc release
+    name: Statically linked LibreSSL 3.x with most recent ponyc release
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.9.2:release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,16 @@ jobs:
       - name: Test
         run: make test config=debug ssl=0.9.0
 
+  test-static-libressl-3-vs-ponyc-release:
+    name: LibreSSL 3.x with most recent ponyc release
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.9.2:release
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Test
+        run: make test config=debug LINK_STATIC=true
+
   test-openssl-1-vs-ponyc-release:
     name: OpenSSL 1.x with most recent ponyc release
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ tags
 .deps/*
 /*.lib
 .vscode
+/libressl-*/
+/libssl.a
+/libcrypto.a

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ libressl-$(LIBRESSL_VERSION)/ssl/.libs/libssl.a: libressl-$(LIBRESSL_VERSION)
 	cd libressl-$(LIBRESSL_VERSION) && ./configure
 	$(MAKE) -C libressl-$(LIBRESSL_VERSION)
 
-libssl.a: libressl-$(LIBRESSL_VERSION)
+libssl.a: libressl-$(LIBRESSL_VERSION)/ssl/.libs/libssl.a
 	cp libressl-$(LIBRESSL_VERSION)/ssl/.libs/libssl.a libssl.a
 
 libressl-$(LIBRESSL_VERSION):

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 
+LINK_STATIC ?= false
+STATIC_DEPS =
+LIBRESSL_VERSION := 3.9.2
+LIBRESSL_DOWNLOAD_URL := "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$(LIBRESSL_VERSION).tar.gz"
+
 BUILD_DIR ?= build/$(config)
 SRC_DIR ?= $(PACKAGE)
 tests_binary := $(BUILD_DIR)/$(PACKAGE)
@@ -22,36 +27,44 @@ else
 	PONYC = ${COMPILE_WITH} --debug
 endif
 
-ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
-  ifeq ($(ssl), 3.0.x)
-	  SSL = -Dopenssl_3.0.x
-  else ifeq ($(ssl), 1.1.x)
-	  SSL = -Dopenssl_1.1.x
-  else ifeq ($(ssl), 0.9.0)
-	  SSL = -Dopenssl_0.9.0
-  else
-    $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+ifeq ($(LINK_STATIC),true)
+	SSL = -Dopenssl_0.9.0 -Dlink_static
+	STATIC_DEPS = libssl.a libcrypto.a
+else
+  ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
+    ifeq ($(ssl), 3.0.x)
+			SSL = -Dopenssl_3.0.x
+    else ifeq ($(ssl), 1.1.x)
+			SSL = -Dopenssl_1.1.x
+    else ifeq ($(ssl), 0.9.0)
+			SSL = -Dopenssl_0.9.0
+    else
+      $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+    endif
   endif
 endif
 
 SOURCE_FILES := $(shell find $(SRC_DIR) -name \*.pony)
+
+all: $(STATIC_DEPS) test
 
 test: unit-tests build-examples
 
 unit-tests: $(tests_binary)
 	$^ --exclude=integration --sequential
 
-$(tests_binary): $(GEN_FILES) $(SOURCE_FILES) | $(BUILD_DIR)
+$(tests_binary): $(STATIC_DEPS) $(GEN_FILES) $(SOURCE_FILES) | $(BUILD_DIR)
 	${GET_DEPENDENCIES_WITH}
 	${PONYC} ${SSL} -o ${BUILD_DIR} $(SRC_DIR)
 
-build-examples:
+build-examples: $(STATIC_DEPS)
 	${GET_DEPENDENCIES_WITH}
 	find examples/*/* -name '*.pony' -print | xargs -n 1 dirname  | sort -u | grep -v ffi- | xargs -n 1 -I {} ${PONYC} ${SSL} -s --checktree -o ${BUILD_DIR} {}
 
 clean:
 	corral clean
 	rm -rf $(BUILD_DIR)
+	rm -rf $(STATIC_DEPS)
 
 $(docs_dir): $(GEN_FILES) $(SOURCE_FILES)
 	rm -rf $(docs_dir)
@@ -63,9 +76,26 @@ docs: $(docs_dir)
 TAGS:
 	ctags --recurse=yes $(SRC_DIR)
 
-all: test
+lib: $(STATIC_DEPS)
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
+
+libressl-$(LIBRESSL_VERSION)/crypto/.libs/libcrypto.a: libressl-$(LIBRESSL_VERSION)
+	cd libressl-$(LIBRESSL_VERSION) && ./configure
+	$(MAKE) -C libressl-$(LIBRESSL_VERSION)
+
+libcrypto.a: libressl-$(LIBRESSL_VERSION)/crypto/.libs/libcrypto.a
+	cp libressl-$(LIBRESSL_VERSION)/crypto/.libs/libcrypto.a libcrypto.a
+
+libressl-$(LIBRESSL_VERSION)/ssl/.libs/libssl.a: libressl-$(LIBRESSL_VERSION)
+	cd libressl-$(LIBRESSL_VERSION) && ./configure
+	$(MAKE) -C libressl-$(LIBRESSL_VERSION)
+
+libssl.a: libressl-$(LIBRESSL_VERSION)
+	cp libressl-$(LIBRESSL_VERSION)/ssl/.libs/libssl.a libssl.a
+
+libressl-$(LIBRESSL_VERSION):
+	curl -s $(LIBRESSL_DOWNLOAD_URL) | tar xz
 
 .PHONY: all clean TAGS test

--- a/corral.json
+++ b/corral.json
@@ -14,6 +14,9 @@
   "scripts": {
     "windows": {
       "post_fetch_or_update": "PowerShell.exe -File make.ps1 -Config release -Command libs"
+    },
+    "posix": {
+        "post_fetch_or_update": "make lib"
     }
   }
 }

--- a/net_ssl/_ssl_init.pony
+++ b/net_ssl/_ssl_init.pony
@@ -1,5 +1,6 @@
-use "path:/usr/local/opt/libressl/lib" if osx and x86
-use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
+use "path:/usr/local/opt/libressl/lib" if osx and x86 and not "link_static"
+use "path:/opt/homebrew/opt/libressl/lib" if osx and arm and not "link_static"
+use "path:.." if posix and "link_static"
 use "lib:ssl"
 use "lib:crypto"
 


### PR DESCRIPTION
This is an experimental change that enables the `net_ssl` package to not depend upon the system openssl variant, but can be compiled with a pinned vendored libressl version. It is presented as a Proof of concept and request for comments.

This feature could be made available by pony applications using this library by enabling a feature switch `-Dlink_static`. The naming of this flag is also just experimental and should have a prefix like `net_ssl`, so it won't collide with other libraries (e.g. `crypto`).

Windows support is also missing. I don't even know if this is even possible on windows.